### PR TITLE
Upgrade to SAMKeychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,32 @@
 
 This is a plugin for Nativescript that allows you to get a UUID (Universal Unique Identifier) for a device.
 
-Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`] (http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
+Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`](http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
 
-Uses [`SSKeychain Cocoa Pod`](https://cocoapods.org/pods/SSKeychain).
+Uses [`SAMKeychain Cocoa Pod`](https://cocoapods.org/pods/SAMKeychain).
 
 ## Installation
-`tns plugin add nativescript-uuid`
+
+Run the following command from the root of your project:
+
+```
+tns plugin add nativescript-uuid
+```
 
 ## Usage
+
+#### JavaScript
+```js
+  const nsUuid = require("nativescript-uuid");
+
+  const uuid = nsUuid.getUUID();
+  console.log(`The device UUID is ${uuid}`);
 ```
-var plugin = require("nativescript-uuid");
-var uuid = plugin.getUUID();
-console.log("The device UUID is " + uuid);
+
+#### TypeScript
+```typescript
+  import {getUUID} from 'nativescript-uuid';
+
+  const uuid = getUUID();
+  console.log(`The device UUID is ${uuid}`);
 ```

--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
-var device = require('../tns-core-modules/platform/platform');
+var device = require('tns-core-modules/platform/platform');
 
 function getUUID() {
   return device ? device.uuid : "";

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,9 @@
 function getUUID() {
     var appName = NSBundle.mainBundle.infoDictionary.objectForKey(kCFBundleNameKey);
-    var strApplicationUUID = SSKeychain.passwordForServiceAccount(appName, "incoding");
+    var strApplicationUUID = SAMKeychain.passwordForService(appName, "incoding");
     if (!strApplicationUUID){
         strApplicationUUID = UIDevice.currentDevice.identifierForVendor.UUIDString;
-        SSKeychain.setPasswordForServiceAccount(strApplicationUUID, appName, "incoding");
+        SAMKeychain.setPassword(strApplicationUUID, appName, "incoding");
     }
 
     return strApplicationUUID;

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SSKeychain'
+pod 'SAMKeychain'


### PR DESCRIPTION
On iOS 12 an older SSKeychain cocoa pod causes an app crash. It is critical to upgrade the plugin to use SAMKeychain.